### PR TITLE
Fix crash when capturing too early

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -91,6 +91,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
     private Camera mCamera = null;
     private Promise mRecordingPromise = null;
     private ReadableMap mRecordingOptions;
+    private boolean mSafeToCapture = true;
 
     public RCTCameraModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -686,6 +687,11 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
         final Boolean shouldMirror = options.hasKey("mirrorImage") && options.getBoolean("mirrorImage");
 
         RCTCamera.getInstance().adjustCameraRotationToDeviceOrientation(options.getInt("type"), deviceOrientation);
+        if (!mSafeToCapture) {
+            Log.w(TAG, "Not capturing picture. Probably another capture is still going on.");
+            return;
+        }
+        mSafeToCapture = false;
         camera.takePicture(null, null, new Camera.PictureCallback() {
             @Override
             public void onPictureTaken(byte[] data, Camera camera) {
@@ -763,6 +769,8 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
                         break;
                     }
                 }
+
+                mSafeToCapture = true;
             }
         });
     }


### PR DESCRIPTION
On many android devices trying to capture an image before a previous
capture finishes, causes a crash.